### PR TITLE
Fix video loading spinners.  They started showing up as solid blue blocks.

### DIFF
--- a/client/createStory/createStory.html
+++ b/client/createStory/createStory.html
@@ -52,7 +52,7 @@
             <input type="text" ng-model="$parent.frame1EndTime" class="form-control" id="endTime1" placeholder="0">
           </div>
           <button type="submit" class="btn btn-success">Preview Act<iron-icon icon="av:movie" class="icon-margin-left"></iron-icon></button>
-          <span><paper-spinner-lite ng-if="showSpinner1" class="blue" active></paper-spinner-lite></span>
+          <span><paper-spinner-lite ng-if="showSpinner1" class="blueSpinner" active></paper-spinner-lite></span>
         </form>
         <div class="col-md-12 clean"></div>
         <div id="frame1Preview" class="col-md-12"></div>
@@ -100,7 +100,7 @@
             <input type="text" ng-model="$parent.frame2EndTime" class="form-control" id="endTime2" placeholder="0">
           </div>
           <button type="submit" class="btn btn-success">Preview Act<iron-icon icon="av:movie" class="icon-margin-left"></iron-icon></button>
-          <span><paper-spinner-lite ng-if="showSpinner2" class="blue" active></paper-spinner-lite></span>
+          <span><paper-spinner-lite ng-if="showSpinner2" class="blueSpinner" active></paper-spinner-lite></span>
         </form>
         <div class="col-md-12 clean"></div>
         <div id="frame2Preview" class="col-md-12"></div>
@@ -148,7 +148,7 @@
             <input type="text" ng-model="$parent.frame3EndTime" class="form-control" id="endTime3" placeholder="0">
           </div>
           <button type="submit" class="btn btn-success">Preview Act<iron-icon icon="av:movie" class="icon-margin-left"></iron-icon></button>
-          <span><paper-spinner-lite ng-if="showSpinner3" class="blue" active></paper-spinner-lite></span>
+          <span><paper-spinner-lite ng-if="showSpinner3" class="blueSpinner" active></paper-spinner-lite></span>
         </form>
         <div class="col-md-12 clean"></div>
         <div id="frame3Preview" class="col-md-12"></div>

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -286,7 +286,7 @@ body {
   padding: 20px;
 }
 
-paper-spinner.blue{
+paper-spinner-lite.blueSpinner{
   --paper-spinner-color: var(--google-blue-500);
 }
 
@@ -302,7 +302,6 @@ paper-spinner.blue{
 
 .blue {
   background-color: #4285F4;
-  /*var(--paper-light-blue-500);*/
 }
 
 .create-page-btn {


### PR DESCRIPTION
* I changed the CSS to target the spinners specifically instead of sharing the 'blue' CSS class with other elements.
* One of the last commits commented out the spinner color and gave the spinners a solid blue background, which explains why they started appearing as solid blue blocks.