### PR TITLE
Refactored StoryStateMachine to work with generic Player objects.

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -9,6 +9,8 @@ var storyBoardApp = angular.module('storyBoardApp', [
                                    'storyBoard.dashboard',
                                    'storyBoard.onUrlErrorDirective',
                                    'storyBoard.createStory',
+                                   'storyBoard.player',
+                                   'storyBoard.videoPlayer',
                                    'storyBoard.storyStateMachineService',
                                    'storyBoard.storyStorageService',
                                    'storyBoard.authService',

--- a/client/createStory/createStory.js
+++ b/client/createStory/createStory.js
@@ -188,7 +188,9 @@ angular.module('storyBoard.createStory', [])
         }
       ]
     }
-    StoryStateMachine.setStory(story);
+    var isSingleStoryView = false;
+    var scope = null;
+    StoryStateMachine.setStory(story, isSingleStoryView, scope);
   }
 
   $scope.destoryFrames = function(){

--- a/client/index.html
+++ b/client/index.html
@@ -38,6 +38,8 @@
   <script src="/lib/angular-animate/angular-animate.js"></script>
 
   <!-- Angular Services/Factories -->
+  <script src="/services/player.js"></script>
+  <script src="/services/videoPlayer.js"></script>
   <script src="/services/storyStateMachine.js"></script>
   <script src="/services/storyStorage.js"></script>
   <script src="/services/authServices.js"></script>

--- a/client/services/player.js
+++ b/client/services/player.js
@@ -1,0 +1,16 @@
+angular.module('storyBoard.player', [])
+
+.factory('Player', function(){
+  function Player(){};
+
+  Player.prototype.create = function(storyFrame, readyCallback, endPlaybackCallback){
+  };
+
+  Player.prototype.destroy = function(){
+  };
+
+  Player.prototype.play = function(){
+  };
+
+  return Player;
+});

--- a/client/services/storyStateMachine.js
+++ b/client/services/storyStateMachine.js
@@ -15,6 +15,13 @@ angular.module('storyBoard.storyStateMachineService', ['storyBoard.videoPlayer']
     closureIsSingleStoryView = isSingleStoryView;
     parentControllerScope = scope;
     var storyFrames = story.frames;
+    // Start with last frame and go backwards
+    // because each player receives a play call
+    // from the player ahead of it.  There could
+    // be a race condition where the first player
+    // wants to start the second player before
+    // the second player is created.  So, we
+    // create them in reverse order.
     var lastFrame = storyFrames.length - 1;
     for(var i = lastFrame; i >= 0; i--) {
       var currentStoryFrame = storyFrames[i];

--- a/client/services/videoPlayer.js
+++ b/client/services/videoPlayer.js
@@ -1,0 +1,66 @@
+angular.module('storyBoard.videoPlayer', ['storyBoard.player'])
+
+.factory('VideoPlayer', function(Player){
+  function VideoPlayer(){
+    this.storyFrame = null;
+    this.endPlaybackCallback = null;
+  }
+
+  VideoPlayer.prototype = Object.create(Player.prototype);
+
+  VideoPlayer.prototype.create = function(storyFrame, readyCallback, endPlaybackCallback){
+    var VIDEO_HEIGHT = 200;
+    var VIDEO_WIDTH = 356;
+    while( ! window.youtubeApiLoadedAndReady){}
+    storyFrame.player =
+      new YT.Player(
+        storyFrame.playerDiv,
+        {
+          height: VIDEO_HEIGHT,
+          width: VIDEO_WIDTH,
+          videoId: storyFrame.videoId,
+          playerVars: {
+            controls: 0,
+            showinfo: 0,
+            start: storyFrame.start,
+            end: storyFrame.end
+          },
+          events: {
+            'onReady': readyCallback.bind(this),
+            'onStateChange': this._onPausedListener.bind(this)
+          }
+        }
+      );
+    this.storyFrame = storyFrame;
+    this.endPlaybackCallback = endPlaybackCallback;
+  };
+
+  VideoPlayer.prototype.destroy = function(){
+    this.storyFrame.player.destroy();
+  };
+
+  VideoPlayer.prototype.play = function(){
+    this.storyFrame.player.playVideo();
+  };
+
+  VideoPlayer.prototype._reset = function(){
+    this.storyFrame.player.cueVideoById(
+      {
+        'videoId': this.storyFrame.videoId,
+        'startSeconds': this.storyFrame.start,
+        'endSeconds': this.storyFrame.end
+      }
+    );
+  };
+
+  VideoPlayer.prototype._onPausedListener = function(event){
+    switch(event.data){
+      case YT.PlayerState.PAUSED:
+        this.endPlaybackCallback();
+        this._reset();
+        break;
+    }
+  }
+
+  return VideoPlayer;
+});

--- a/client/singleStory/singleStory.js
+++ b/client/singleStory/singleStory.js
@@ -14,7 +14,8 @@ angular.module('storyBoard.singleStory', [])
   .then(function (story) {
     $scope.storyTitle = story.data.title;
     $scope.storyUsername = story.data.username;
-    StoryStateMachine.setStory(story.data, $scope);
+    var isSingleStoryView = true;
+    StoryStateMachine.setStory(story.data, isSingleStoryView, $scope);
   });
 
   $scope.voteUp = function () {


### PR DESCRIPTION
* Created a generic Player interface.  
* Created a VideoPlayer interface that implements the Player interface. 
* The StoryStateMachine now does not make any assumptions as to what type of player is in a frame.  It just calls 'play' on it.  
* Next, we can create an AudioPlayer or NarrationPlayer that implements the same 'Player' interface and the StoryStateMachine can automatically work with it.
* Also, fixed bug with story preview being broken.