### PR TITLE
Adding image media type support for storyboard.

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -11,6 +11,7 @@ var storyBoardApp = angular.module('storyBoardApp', [
                                    'storyBoard.createStory',
                                    'storyBoard.player',
                                    'storyBoard.videoPlayer',
+                                   'storyBoard.imagePlayer',
                                    'storyBoard.storyStateMachineService',
                                    'storyBoard.storyStorageService',
                                    'storyBoard.authService',

--- a/client/createStory/createStory.html
+++ b/client/createStory/createStory.html
@@ -181,9 +181,9 @@
         <div class="modal-content">
             <div class="modal-header preview-modal-header">
                 <h1>Preview</h1>
-                <div id="player1"></div>
-                <div id="player2"></div>
-                <div id="player3"></div>
+                <div id="player1" style="display:inline;"></div>
+                <div id="player2" style="display:inline;"></div>
+                <div id="player3" style="display:inline;"></div>
                 <div class="modal-footer preview-modal-footer">
                     <button type="button" class="btn btn-success" data-dismiss="modal"  data-target="#myModal" ng-click="saveStory()">Save your story<iron-icon icon="icons:save" class="icon-margin-left"></iron-icon></button>
                     <button type="button" class="btn btn-danger" ng-click="destoryFrames()" data-dismiss="modal">Close<iron-icon icon="icons:close" class="icon-margin-left"></iron-icon></button>

--- a/client/createStory/createStory.js
+++ b/client/createStory/createStory.js
@@ -25,26 +25,41 @@ angular.module('storyBoard.createStory', [])
     $scope.storyDescription = editStory.description;
     $scope.storyThumbnailUrl = editStory.thumbnail;
 
-    $scope.frame1MediaType = null; //TODO: fill in
+    // TODO: remove backwards compatibility
+    if(editStory.frames[0].mediaType !== undefined) {
+      $scope.frame1MediaType = editStory.frames[0].mediaType;
+    } else {
+      $scope.frame1MediaType = null;
+    }
     $scope.frame1YoutubeUrl = recreateVideoUrl(editStory.frames[0].videoId);
     $scope.frame1StartTime = editStory.frames[0].start;
     $scope.frame1EndTime = editStory.frames[0].end;
-    $scope.frame1ImageUrl = null; //TODO: fill in
-    $scope.frame1UrlDuration = null; //TODO: fill in
+    $scope.frame1ImageUrl = editStory.frames[0].imageUrl;
+    $scope.frame1UrlDuration = editStory.frames[0].imageDuration;
 
-    $scope.frame2MediaType = null; //TODO: fill in
+    // TODO: remove backwards compatibility
+    if(editStory.frames[1].mediaType !== undefined) {
+      $scope.frame2MediaType = editStory.frames[1].mediaType;
+    } else {
+      $scope.frame2MediaType = null;
+    }
     $scope.frame2YoutubeUrl = recreateVideoUrl(editStory.frames[1].videoId);
     $scope.frame2StartTime = editStory.frames[1].start;
     $scope.frame2EndTime = editStory.frames[1].end;
-    $scope.frame2ImageUrl = null; //TODO: fill in
-    $scope.frame2UrlDuration = null; //TODO: fill in
+    $scope.frame2ImageUrl = editStory.frames[1].imageUrl;
+    $scope.frame2UrlDuration = editStory.frames[1].imageDuration;
 
-    $scope.frame3MediaType = null; //TODO: fill in
+    // TODO: remove backwards compatibility
+    if(editStory.frames[2].mediaType !== undefined) {
+      $scope.frame3MediaType = editStory.frames[2].mediaType;
+    } else {
+      $scope.frame3MediaType = null;
+    }
     $scope.frame3YoutubeUrl = recreateVideoUrl(editStory.frames[2].videoId);
     $scope.frame3StartTime = editStory.frames[2].start;
     $scope.frame3EndTime = editStory.frames[2].end;
-    $scope.frame3ImageUrl = null; //TODO: fill in
-    $scope.frame3UrlDuration = null; //TODO: fill in
+    $scope.frame3ImageUrl = editStory.frames[2].imageUrl;
+    $scope.frame3UrlDuration = editStory.frames[2].imageDuration;
   } else {
     $scope.storyTitle = null;
     $scope.storyDescription = null;
@@ -99,16 +114,53 @@ angular.module('storyBoard.createStory', [])
   }
 
   $scope.checkRequiredFields = function(){
-    var allFieldsReady =
+    var storyMetaInfoReady =
       $scope.storyTitle        &&
       $scope.storyDescription  &&
-      $scope.storyThumbnailUrl &&
-      $scope.frame1YoutubeUrl  &&
-      $scope.frame1EndTime     &&
-      $scope.frame2YoutubeUrl  &&
-      $scope.frame2EndTime     &&
-      $scope.frame3YoutubeUrl  &&
+      $scope.storyThumbnailUrl;
+
+    var video1InfoReady =
+      $scope.frame1YoutubeUrl &&
+      $scope.frame1EndTime;
+
+    var image1InfoReady =
+      $scope.frame1ImageUrl &&
+      $scope.frame1UrlDuration;
+
+    var frame1Ready =
+      video1InfoReady ||
+      image1InfoReady;
+
+    var video2InfoReady =
+      $scope.frame2YoutubeUrl &&
+      $scope.frame2EndTime;
+
+    var image2InfoReady =
+      $scope.frame2ImageUrl &&
+      $scope.frame2UrlDuration;
+
+    var frame2Ready =
+      video2InfoReady ||
+      image2InfoReady;
+
+    var video3InfoReady =
+      $scope.frame3YoutubeUrl &&
       $scope.frame3EndTime;
+
+    var image3InfoReady =
+      $scope.frame3ImageUrl &&
+      $scope.frame3UrlDuration;
+
+    var frame3Ready =
+      video3InfoReady ||
+      image3InfoReady;
+
+    var allFieldsReady =
+      storyMetaInfoReady &&
+      frame1Ready        &&
+      frame2Ready        &&
+      frame3Ready;
+
     return allFieldsReady;
   }
 
@@ -124,25 +176,34 @@ angular.module('storyBoard.createStory', [])
       FRAME3: 2,
       frames: [
         {
+          mediaType: $scope.frame1MediaType,
           player: null,
           playerDiv: 'player1',
           videoId: stripOutVideoIdFromUrl($scope.frame1YoutubeUrl),
           start: parseInt($scope.frame1StartTime),
-          end: parseInt($scope.frame1EndTime)
+          end: parseInt($scope.frame1EndTime),
+          imageUrl: $scope.frame1ImageUrl,
+          imageDuration: $scope.frame1UrlDuration
         },
         {
+          mediaType: $scope.frame2MediaType,
           player: null,
           playerDiv: 'player2',
           videoId: stripOutVideoIdFromUrl($scope.frame2YoutubeUrl),
           start: parseInt($scope.frame2StartTime),
-          end: parseInt($scope.frame2EndTime)
+          end: parseInt($scope.frame2EndTime),
+          imageUrl: $scope.frame2ImageUrl,
+          imageDuration: $scope.frame2UrlDuration
         },
         {
+          mediaType: $scope.frame3MediaType,
           player: null,
           playerDiv: 'player3',
           videoId: stripOutVideoIdFromUrl($scope.frame3YoutubeUrl),
           start: parseInt($scope.frame3StartTime),
-          end: parseInt($scope.frame3EndTime)
+          end: parseInt($scope.frame3EndTime),
+          imageUrl: $scope.frame3ImageUrl,
+          imageDuration: $scope.frame3UrlDuration
         }
       ]
     }
@@ -166,25 +227,34 @@ angular.module('storyBoard.createStory', [])
       FRAME3: 2,
       frames: [
         {
+          mediaType: $scope.frame1MediaType,
           player: null,
           playerDiv: 'player1',
           videoId: stripOutVideoIdFromUrl($scope.frame1YoutubeUrl),
           start: $scope.frame1StartTime,
-          end: $scope.frame1EndTime
+          end: $scope.frame1EndTime,
+          imageUrl: $scope.frame1ImageUrl,
+          imageDuration: $scope.frame1UrlDuration
         },
         {
+          mediaType: $scope.frame2MediaType,
           player: null,
           playerDiv: 'player2',
           videoId: stripOutVideoIdFromUrl($scope.frame2YoutubeUrl),
           start: $scope.frame2StartTime,
-          end: $scope.frame2EndTime
+          end: $scope.frame2EndTime,
+          imageUrl: $scope.frame2ImageUrl,
+          imageDuration: $scope.frame2UrlDuration
         },
         {
+          mediaType: $scope.frame3MediaType,
           player: null,
           playerDiv: 'player3',
           videoId: stripOutVideoIdFromUrl($scope.frame3YoutubeUrl),
           start: $scope.frame3StartTime,
-          end: $scope.frame3EndTime
+          end: $scope.frame3EndTime,
+          imageUrl: $scope.frame3ImageUrl,
+          imageDuration: $scope.frame3UrlDuration
         }
       ]
     }

--- a/client/createStory/createStory.js
+++ b/client/createStory/createStory.js
@@ -180,30 +180,30 @@ angular.module('storyBoard.createStory', [])
           player: null,
           playerDiv: 'player1',
           videoId: stripOutVideoIdFromUrl($scope.frame1YoutubeUrl),
-          start: parseInt($scope.frame1StartTime),
-          end: parseInt($scope.frame1EndTime),
+          start: $scope.frame1StartTime ? parseInt($scope.frame1StartTime) : 0,
+          end: $scope.frame1EndTime ? parseInt($scope.frame1EndTime) : 0,
           imageUrl: $scope.frame1ImageUrl,
-          imageDuration: $scope.frame1UrlDuration
+          imageDuration: $scope.frame1UrlDuration ? parseInt($scope.frame1UrlDuration) : 0
         },
         {
           mediaType: $scope.frame2MediaType,
           player: null,
           playerDiv: 'player2',
           videoId: stripOutVideoIdFromUrl($scope.frame2YoutubeUrl),
-          start: parseInt($scope.frame2StartTime),
-          end: parseInt($scope.frame2EndTime),
+          start: $scope.frame2StartTime ? parseInt($scope.frame2StartTime) : 0,
+          end: $scope.frame2EndTime ? parseInt($scope.frame2EndTime) : 0,
           imageUrl: $scope.frame2ImageUrl,
-          imageDuration: $scope.frame2UrlDuration
+          imageDuration: $scope.frame2UrlDuration ? parseInt($scope.frame2UrlDuration) : 0
         },
         {
           mediaType: $scope.frame3MediaType,
           player: null,
           playerDiv: 'player3',
           videoId: stripOutVideoIdFromUrl($scope.frame3YoutubeUrl),
-          start: parseInt($scope.frame3StartTime),
-          end: parseInt($scope.frame3EndTime),
+          start: $scope.frame3StartTime ? parseInt($scope.frame3StartTime) : 0,
+          end: $scope.frame3EndTime ? parseInt($scope.frame3EndTime) : 0,
           imageUrl: $scope.frame3ImageUrl,
-          imageDuration: $scope.frame3UrlDuration
+          imageDuration: $scope.frame3UrlDuration ? parseInt($scope.frame3UrlDuration) : 0
         }
       ]
     }
@@ -376,6 +376,8 @@ angular.module('storyBoard.createStory', [])
   }
 
   var stripOutVideoIdFromUrl = function(url){
+    if( ! url) return url;
+
     var videoId = url.split('v=')[1];
     var ampersandIndex = videoId.indexOf('&');
     if(ampersandIndex !== -1){

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -80,6 +80,10 @@ body {
     color: white;
 }
 
+.showImageFrame {
+  visibility: visible !important;
+  vertical-align: baseline !important;
+}
 
 .row {
   margin-left: 0px;

--- a/client/index.html
+++ b/client/index.html
@@ -41,6 +41,7 @@
   <!-- Angular Services/Factories -->
   <script src="/services/player.js"></script>
   <script src="/services/videoPlayer.js"></script>
+  <script src="/services/imagePlayer.js"></script>
   <script src="/services/storyStateMachine.js"></script>
   <script src="/services/storyStorage.js"></script>
   <script src="/services/authServices.js"></script>

--- a/client/services/imagePlayer.js
+++ b/client/services/imagePlayer.js
@@ -1,0 +1,44 @@
+angular.module('storyBoard.imagePlayer', ['storyBoard.player'])
+
+.factory('ImagePlayer', function(Player){
+  function ImagePlayer(){
+    this.imageDuration = null;
+    this.playerDiv = null;
+    this.endPlaybackCallback = null;
+  }
+
+  ImagePlayer.prototype = Object.create(Player.prototype);
+
+  ImagePlayer.prototype.create = function(storyFrame, readyCallback, endPlaybackCallback){
+    // Save image duration and end playback callback for later
+    this.imageDuration = storyFrame.imageDuration;
+    this.endPlaybackCallback = endPlaybackCallback;
+
+    // Add image to DOM
+    var divId = '#' + storyFrame.playerDiv;
+    this.playerDiv = angular.element(document.querySelector(divId));
+    var imageURL = storyFrame.imageUrl;
+    var imgTagStr = '<img src=\"' + imageURL + '\" style=\"visibility:hidden;\" height=\"200\" width=\"356\">';
+    this.playerDiv.append(imgTagStr);
+
+    readyCallback.call(this);
+  };
+
+  ImagePlayer.prototype.destroy = function(){
+    this.playerDiv.empty();
+  };
+
+  ImagePlayer.prototype.play = function(){
+    var imgTag = this.playerDiv.children();
+    imgTag.addClass('showImageFrame');
+    var durationInMilliseconds = this.imageDuration * 1000;
+    var boundEndPlaybackCallback = this.endPlaybackCallback.bind(this);
+    setTimeout(function(){
+        boundEndPlaybackCallback();
+      },
+      durationInMilliseconds
+    );
+  };
+
+  return ImagePlayer;
+});

--- a/client/services/storyStateMachine.js
+++ b/client/services/storyStateMachine.js
@@ -1,6 +1,8 @@
-angular.module('storyBoard.storyStateMachineService', ['storyBoard.videoPlayer'])
+angular.module('storyBoard.storyStateMachineService',
+  ['storyBoard.videoPlayer',
+   'storyBoard.imagePlayer'])
 
-.factory('StoryStateMachine', function(VideoPlayer){
+.factory('StoryStateMachine', function(VideoPlayer, ImagePlayer){
   var storyStateMachine = {};
   storyStateMachine.story = null;
   var closureIsSingleStoryView = false;
@@ -27,7 +29,7 @@ angular.module('storyBoard.storyStateMachineService', ['storyBoard.videoPlayer']
       var currentStoryFrame = storyFrames[i];
       var readyCallback = this._determineReadyCallback(i);
       var endPlayBackCallback = this._determineEndPlaybackCallback(i);
-      var newFramePlayer = new VideoPlayer();
+      var newFramePlayer = this._createPlayer(currentStoryFrame.mediaType);
       newFramePlayer.create(
         currentStoryFrame,
         readyCallback,
@@ -45,6 +47,29 @@ angular.module('storyBoard.storyStateMachineService', ['storyBoard.videoPlayer']
     storyStateMachine.players = [];
     parentControllerScope = null;
   };
+
+  storyStateMachine._createPlayer = function(mediaType){
+    var player = null;
+    // TODO: Old story backwards compatibility
+    if(mediaType === undefined){
+      mediaType = 0;
+    }
+    // End backwards compatiblity
+
+    switch(mediaType){
+      case 0:
+        player = new VideoPlayer();
+        break;
+      case 1:
+        player = new ImagePlayer();
+        break;
+      default:
+        throw "Unrecognized media type in storyStateMachine.js";
+        break;
+    }
+
+    return player;
+  }
 
   storyStateMachine._determineReadyCallback = function(frameNum){
     var readyCallback = function(){};
@@ -96,30 +121,56 @@ angular.module('storyBoard.storyStateMachineService', ['storyBoard.videoPlayer']
   };
 
   function _growAct1() {
-    parentControllerScope.$apply(function () {
+    if(_isAngularAlreadyMonitoringDOM()) {
       parentControllerScope.act1divclass = 'growact1';
-    });
+    } else {
+      // Force Angular to re-render
+      parentControllerScope.$apply(function () {
+        parentControllerScope.act1divclass = 'growact1';
+      });
+    }
   };
 
   function _shrinkAct1AndGrowAct2() {
-    parentControllerScope.$apply(function () {
+    if(_isAngularAlreadyMonitoringDOM()) {
       parentControllerScope.act1divclass = 'a';
       parentControllerScope.act2divclass = 'growact2';
-    });
+    } else {
+      // Force Angular to re-render
+      parentControllerScope.$apply(function () {
+        parentControllerScope.act1divclass = 'a';
+        parentControllerScope.act2divclass = 'growact2';
+      });
+    }
   };
 
   function _shrinkAct2AndGrowAct3() {
-    parentControllerScope.$apply(function () {
+    if(_isAngularAlreadyMonitoringDOM()) {
       parentControllerScope.act2divclass = 'a';
       parentControllerScope.act3divclass = 'growact3';
-    });
+    } else {
+      // Force Angular to re-render
+      parentControllerScope.$apply(function () {
+        parentControllerScope.act2divclass = 'a';
+        parentControllerScope.act3divclass = 'growact3';
+      });
+    }
   };
 
   function _shrinkAct3() {
-    parentControllerScope.$apply(function () {
+    if(_isAngularAlreadyMonitoringDOM()) {
       parentControllerScope.act3divclass = 'a';
-    });
+    } else {
+      // Force Angular to re-render
+      parentControllerScope.$apply(function () {
+        parentControllerScope.act3divclass = 'a';
+      });
+    }
   };
+
+  function _isAngularAlreadyMonitoringDOM() {
+    return parentControllerScope.$$phase;
+  }
 
   return storyStateMachine;
 });

--- a/server/src/schema.go
+++ b/server/src/schema.go
@@ -38,11 +38,14 @@ type Story struct {
 
 // Frame model for Acts/Scenes
 type Frame struct {
-	Player    struct{} `json:"player"`
-	PlayerDiv string   `json:"playerDiv"`
-	VideoId   string   `json:"videoId"`
-	Start     float32  `json:"start"`
-	End       float32  `json:"end"`
+	MediaType     int      `json:"mediaType"`
+	Player        struct{} `json:"player"`
+	PlayerDiv     string   `json:"playerDiv"`
+	VideoId       string   `json:"videoId"`
+	Start         float32  `json:"start"`
+	End           float32  `json:"end"`
+	ImageUrl      string   `json:"imageUrl"`
+	ImageDuration int      `json:"imageDuration"`
 }
 
 // Vote Model - separate collection


### PR DESCRIPTION
* New "ImagePlayer" class that implements the "Player" interface.
* Forcing player Divs to be inline b/c img tags don't show up automatically inline like Youtube iFrames.
* Adding temporary backwards compatibility for older stories that don't have a media type defined.
* Refactoring createStory.js's checkRequiredFields to allow either frames to be images or videos but not require both.
* Handling empty fields on the create story page when the fields do not apply to the media type.
* Adding a _createPlayer function to storyStateMachine.js to create the appropriate Player based on media type.
* Adding a _isAngularAlreadyMonitoringDOM function to check if it is OK to call $apply or not.  The images appear to load fast enough that Angular is already re-rendering the page based on changes.
