### PR TITLE
Editing stories changes non-animated preview images

### DIFF
--- a/server/src/image.go
+++ b/server/src/image.go
@@ -161,9 +161,8 @@ func getGifDimensions(gif *gif.GIF) (x, y int) {
 	return highestX - lowestX, highestY - lowestY
 }
 
-// Save a non-animated version of a GIF in the database.
-// The stored image will be a PNG.
-// Return a url path which can the client can use to request the stored image.
+// Delete a non-animated version of a GIF in the database.
+// 'imageUrl' will look like '/api/images/<image_id>'
 func deleteNonAnimatedGif(imageUrl string) (error, int) {
 	// Get the imageId from the endpoint of the imageUrl.
 	imageId := filepath.Base(imageUrl)

--- a/server/src/image.go
+++ b/server/src/image.go
@@ -132,6 +132,7 @@ func saveNonAnimatedGif(imageUrl string) (string, error) {
 	// Return the url path which the client can use
 	//   to request the new PNG image.
 	previewUrl := concat("/api/images/", dbFileIdHex)
+	fmt.Printf("previewUrl: %v\n", previewUrl)
 	return previewUrl, nil
 }
 
@@ -158,4 +159,27 @@ func getGifDimensions(gif *gif.GIF) (x, y int) {
 	}
 
 	return highestX - lowestX, highestY - lowestY
+}
+
+// Save a non-animated version of a GIF in the database.
+// The stored image will be a PNG.
+// Return a url path which can the client can use to request the stored image.
+func deleteNonAnimatedGif(imageUrl string) (error, int) {
+	// Get the imageId from the endpoint of the imageUrl.
+	imageId := filepath.Base(imageUrl)
+
+	// Convert the imageId to an Mongo ObjectId.
+	imageObjectId := bson.ObjectIdHex(imageId)
+
+	// Remove the image file with this id from the database.
+	err := dbFs.RemoveId(imageObjectId)
+	if err != nil {
+		return fmt.Errorf(
+				"Failed to remove image %v in the database: %v",
+				imageId, err,
+			),
+			http.StatusInternalServerError
+	}
+
+	return nil, http.StatusOK
 }

--- a/server/src/schema.go
+++ b/server/src/schema.go
@@ -46,8 +46,8 @@ type Frame struct {
 	Start         float32  `json:"start"`
 	End           float32  `json:"end"`
 	Volume        int      `json:"volume"`
-	PreviewUrl    string   `json:"previewUrl"`
-	ImageUrl      string   `json:"imageUrl"`
+	PreviewUrl    string   `json:"previewUrl" bson:"previewurl"`
+	ImageUrl      string   `json:"imageUrl" bson:"imageurl"`
 	ImageDuration int      `json:"imageDuration"`
 }
 

--- a/server/src/story.go
+++ b/server/src/story.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"net/http"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"gopkg.in/mgo.v2/bson"
@@ -111,7 +112,8 @@ func saveStory(w http.ResponseWriter, r *http.Request) (error, int) {
 	story.CreatedAt = time.Now()
 
 	// Set defaults for 'story.Frames'.
-	for i := 0; i < 3; i++ {
+	numberOfFrames := len(story.Frames)
+	for i := 0; i < numberOfFrames; i++ {
 		frame := &story.Frames[i]
 		// Skip if the previewUrl is already set.
 		if frame.PreviewUrl != "" {
@@ -375,6 +377,96 @@ func editStory(w http.ResponseWriter, r *http.Request) (error, int) {
 		return err, status
 	}
 
+	// Fetch the unedited story data from the database.
+	originalStory := Story{}
+	err = storiesCollection.Find(bson.M{
+		"_id": story.Id,
+	}).One(&originalStory)
+	if err != nil {
+		return fmt.Errorf("Original story not found in the database\n"),
+			http.StatusNotFound
+	}
+
+	// If the story contains GIF's,
+	//   remove the non-animated versions of them in the database.
+	numberOfFrames := len(story.Frames)
+
+	// Prepare to watch multi-threaded goroutines.
+	var wg sync.WaitGroup
+	wg.Add(numberOfFrames)
+
+	for i := 0; i < numberOfFrames; i++ {
+		// Set each frame's PreviewUrl concurrently.
+		go func(i int) {
+			// At the end of this goroutine,
+			//   tell 'wg' that another goroutine is done.
+			defer wg.Done()
+
+			editedFrame := &story.Frames[i]
+			originalFrame := originalStory.Frames[i]
+
+			// Set the editedFrame's PreviewUrl (for the home/splash page).
+			// Handle images and videos differently.
+			switch editedFrame.MediaType {
+
+			// Set a video's PreviewUrl.
+			case 0:
+				// Set the PreviewUrl to the first frame in the YouTube video.
+				videoId := editedFrame.VideoId
+				previewUrl := concat(
+					"https://img.youtube.com/vi/", videoId, "/1.jpg",
+				)
+				(*editedFrame).PreviewUrl = previewUrl
+
+			// Set an image's PreviewUrl.
+			case 1:
+
+				editedImageUrl := editedFrame.ImageUrl
+
+				// Handle GIF images differently than other images.
+				switch filepath.Ext(editedImageUrl) {
+				case ".gif":
+					// Skip if the ImageUrl has not been edited.
+					if editedImageUrl == originalFrame.ImageUrl {
+						return
+					}
+
+					// Save a non-animated version of the GIF in the database.
+					nonAnimatedPreviewUrl, err := saveNonAnimatedGif(
+						editedImageUrl,
+					)
+
+					// Note the '==' here instead of the usual '!='.
+					if err == nil {
+						// If a non-animated copy of the GIF
+						//   was saved successfully,
+						//   remove the old image from the database.
+						go deleteNonAnimatedGif(editedFrame.PreviewUrl)
+
+						// Use the non-animated version of the GIF
+						//   as the PreviewUrl.
+						(*editedFrame).PreviewUrl = nonAnimatedPreviewUrl
+						break
+					}
+
+					// If an error occurred, treat the GIF as a normal image.
+					fmt.Printf(
+						"Failed to create a non-animated version of %v: %v\n",
+						editedImageUrl, err,
+					)
+					fallthrough
+
+				// For non-GIF images, set the PreviewUrl to the ImageUrl.
+				default:
+					(*editedFrame).PreviewUrl = editedImageUrl
+				}
+			}
+		}(i)
+	}
+
+	// Wait for goroutines to finish.
+	wg.Wait()
+
 	// Fetch story data from the database.
 	err = storiesCollection.Update(
 		bson.M{"_id": story.Id},
@@ -440,6 +532,34 @@ func deleteStory(w http.ResponseWriter, r *http.Request, storyId string) (error,
 	err, status = user.verifyAuthorship(storyId)
 	if err != nil {
 		return err, status
+	}
+
+	// If the story contains GIF's,
+	//   remove the non-animated versions of them in the database.
+	numberOfFrames := len(story.Frames)
+	for i := 0; i < numberOfFrames; i++ {
+		frame := &story.Frames[i]
+
+		// Skip is the frame is not an image.
+		if frame.MediaType != 1 {
+			continue
+		}
+
+		// Skip is the frame is not a GIF.
+		if filepath.Ext(frame.ImageUrl) != ".gif" {
+			continue
+		}
+
+		// Skip if the PreviewUrl does not point to an image in the database.
+		if filepath.Dir(frame.PreviewUrl) != "/api/images" {
+			continue
+		}
+
+		// Remove the file from the database.
+		err, status := deleteNonAnimatedGif(frame.PreviewUrl)
+		if err != nil {
+			return err, status
+		}
 	}
 
 	// Remove story data from the database.


### PR DESCRIPTION
When editing stories, if a gif image is edited, a new preview image for the splash page is created, and the old preview image is removed from the database.

But if a story switches an act from a gif to a video, the old preview image for the gif is not deleted in the database. I haven't added that feature yet; I don't think a fix for it is urgent right now.