### PR TITLE
Fixing modal playback/closing issues.

### DIFF
--- a/client/createStory/createStory.html
+++ b/client/createStory/createStory.html
@@ -23,7 +23,7 @@
       <div ng-show="checkRequiredFields()">
         <button type="button" class="btn btn-success create-page-btn" ng-click="previewStory()" data-toggle="modal" data-target="#myModal">Preview Story<iron-icon icon="av:play-circle-outline" class="icon-margin-left"></iron-icon></button>
         <div class="row clean"></div>
-        <button type="button" class="btn btn-success saveButton create-page-btn" ng-click="saveStory()">Save your story<iron-icon icon="icons:save" class="icon-margin-left"></iron-icon></button>
+        <button type="button" class="btn btn-success saveButton create-page-btn" ng-click="saveStory(false)">Save your story<iron-icon icon="icons:save" class="icon-margin-left"></iron-icon></button>
       </div>
     </paper-card>
   </div>
@@ -269,8 +269,8 @@
                 <div id="player3" style="display:inline;"></div>
                 <div ng-show="!!$parent.frame0YoutubeUrl" id="player0" style="display:inline;"></div>
                 <div class="modal-footer preview-modal-footer">
-                    <button type="button" class="btn btn-success" data-dismiss="modal"  data-target="#myModal" ng-click="saveStory()">Save your story<iron-icon icon="icons:save" class="icon-margin-left"></iron-icon></button>
-                    <button type="button" class="btn btn-danger" ng-click="destoryFrames()" data-dismiss="modal">Close<iron-icon icon="icons:close" class="icon-margin-left"></iron-icon></button>
+                    <button type="button" class="btn btn-success" data-dismiss="modal"  data-target="#myModal" ng-click="saveStory(true)">Save your story<iron-icon icon="icons:save" class="icon-margin-left"></iron-icon></button>
+                    <button type="button" class="btn btn-danger" ng-click="destroyFrames()" data-dismiss="modal">Close<iron-icon icon="icons:close" class="icon-margin-left"></iron-icon></button>
                 </div>
             </div>
         </div>

--- a/client/createStory/createStory.js
+++ b/client/createStory/createStory.js
@@ -233,7 +233,11 @@ angular.module('storyBoard.createStory', [])
     return allFieldsReady;
   }
 
-  $scope.saveStory = function(){
+  $scope.saveStory = function(isPreviewModal){
+    if(isPreviewModal){
+      $scope.destroyFrames();
+    }
+
     var story = {
       title: $scope.storyTitle,
       description: $scope.storyDescription,
@@ -374,7 +378,7 @@ angular.module('storyBoard.createStory', [])
     StoryStateMachine.setStory(story, isSingleStoryView, scope);
   }
 
-  $scope.destoryFrames = function(){
+  $scope.destroyFrames = function(){
     StoryStateMachine.endStory();
   }
 

--- a/client/services/storyStateMachine.js
+++ b/client/services/storyStateMachine.js
@@ -7,6 +7,7 @@ angular.module('storyBoard.storyStateMachineService',
   var storyStateMachine = {};
   storyStateMachine.story = null;
   var closureIsSingleStoryView = false;
+  var closureStoryHasEnded = false;
   storyStateMachine.players = [];
   var parentControllerScope = null;
   var AUDIO = 0;
@@ -16,6 +17,7 @@ angular.module('storyBoard.storyStateMachineService',
 
   storyStateMachine.setStory = function(story, isSingleStoryView, scope){
     this.story = story;
+    closureStoryHasEnded = false;
     closureIsSingleStoryView = isSingleStoryView;
     parentControllerScope = scope;
     var storyFrames = story.frames;
@@ -48,6 +50,7 @@ angular.module('storyBoard.storyStateMachineService',
   }
 
   storyStateMachine.endStory = function(){
+    closureStoryHasEnded = true;
     var storyPlayers = this.players;
     storyPlayers.forEach(function(player){
       player.destroy();
@@ -122,6 +125,14 @@ angular.module('storyBoard.storyStateMachineService',
         if(closureIsSingleStoryView) {
           _shrinkAct1AndGrowAct2();
         }
+
+        // Do not attempt to move story
+        // forward if it has ended.
+        // This is here because these
+        // callbacks are asynchronous
+        // and could run after endStory()
+        if(closureStoryHasEnded) return;
+
         storyStateMachine.players[SECOND].play();
       };
     } else if(isSecondFrame) {
@@ -129,6 +140,14 @@ angular.module('storyBoard.storyStateMachineService',
         if(closureIsSingleStoryView) {
           _shrinkAct2AndGrowAct3();
         }
+
+        // Do not attempt to move story
+        // forward if it has ended.
+        // This is here because these
+        // callbacks are asynchronous
+        // and could run after endStory()
+        if(closureStoryHasEnded) return;
+
         storyStateMachine.players[THIRD].play();
       };
     } else if(isThirdFrame) {
@@ -136,6 +155,14 @@ angular.module('storyBoard.storyStateMachineService',
         if(closureIsSingleStoryView) {
           _shrinkAct3();
         }
+
+        // Do not attempt to move story
+        // forward if it has ended.
+        // This is here because these
+        // callbacks are asynchronous
+        // and could run after endStory()
+        if(closureStoryHasEnded) return;
+
         storyStateMachine.players[AUDIO].pause();
       };
     }


### PR DESCRIPTION
* Fix for console errors when closing story preview while playing.
* saveStory() now calls destroyFrames if it is called from Story Preview (modal) to stop any possibility of the story to continue playing once we get to the dashboard. Passing boolean to saveStory() to distinguish b/w modal and regular Create Story screen. Rename misspelled destoryFrames to destroyFrames.