### PR TITLE
Removing the getUserToken() call from the parseBody function.

### DIFF
--- a/server/src/user.go
+++ b/server/src/user.go
@@ -218,11 +218,7 @@ func parseBody(w http.ResponseWriter, r *http.Request) (User, error, int) {
 			http.StatusBadRequest
 	}
 
-	// Get the token from the header.
-	var status int
-	user.Token, err, status = getUserToken(r)
-
-	return user, err, status
+	return user, err, http.StatusOK
 }
 
 // Return a bool whether a user's token is valid.


### PR DESCRIPTION
It is not needed and we use parseBody for SignUp and SignIn when there is no token so the getUserToken() function is guaranteed to fail.