### PR TITLE
Bug fix for replay with no Audio Soundtrack

### DIFF
--- a/client/services/storyStateMachine.js
+++ b/client/services/storyStateMachine.js
@@ -50,10 +50,13 @@ angular.module('storyBoard.storyStateMachineService',
   };
 
   storyStateMachine.restartStory = function () {
-    var audioStoryPlayer = this.players[AUDIO];
-    this._zeroFrameReady.call(audioStoryPlayer);
-    var firstStoryPlayer = this.players[FIRST];
-    this._firstFrameReady.call(firstStoryPlayer);
+    if (this.story.hasSoundtrack) {
+      var audioStoryPlayer = this.players[AUDIO];
+      this._zeroFrameReady.call(audioStoryPlayer);
+    } else {
+      var firstStoryPlayer = this.players[FIRST];
+      this._firstFrameReady.call(firstStoryPlayer);
+    }
   }
 
   storyStateMachine.endStory = function(){


### PR DESCRIPTION
Logic should allow for replay even if there is no soundtrack.  It should
just launch the 1st frame if there is no 0th (or audio frame) to launch.