### PR TITLE
"Edit Story with a soundtrack already" display bug

### DIFF
--- a/client/createStory/createStory.js
+++ b/client/createStory/createStory.js
@@ -46,6 +46,7 @@ angular.module('storyBoard.createStory', [])
     if (editStory.frames[0].videoId !== "") {
       $scope.frame0YoutubeUrl = recreateVideoUrl(editStory.frames[0].videoId);
       $scope.addSoundTrack = true;
+      $scope.audioTrackDisplay = 'Destroy Soundtrack';
     } else {
       $scope.frame0YoutubeUrl = "";
       $scope.addSoundTrack = false;

--- a/client/createStory/createStory.js
+++ b/client/createStory/createStory.js
@@ -50,6 +50,7 @@ angular.module('storyBoard.createStory', [])
     } else {
       $scope.frame0YoutubeUrl = "";
       $scope.addSoundTrack = false;
+      $scope.audioTrackDisplay = "Add Soundtrack";
     }
     $scope.frame0StartTime = editStory.frames[0].start;
     $scope.frame0EndTime = editStory.frames[0].end;

--- a/client/createStory/createStory.js
+++ b/client/createStory/createStory.js
@@ -46,7 +46,7 @@ angular.module('storyBoard.createStory', [])
     if (editStory.frames[0].videoId !== "") {
       $scope.frame0YoutubeUrl = recreateVideoUrl(editStory.frames[0].videoId);
       $scope.addSoundTrack = true;
-      $scope.audioTrackDisplay = 'Destroy Soundtrack';
+      $scope.audioTrackDisplay = 'Remove Soundtrack';
     } else {
       $scope.frame0YoutubeUrl = "";
       $scope.addSoundTrack = false;
@@ -547,7 +547,7 @@ angular.module('storyBoard.createStory', [])
   $scope.toggleSoundTrack = function () {
     $scope.addSoundTrack = !$scope.addSoundTrack;
     if ($scope.addSoundTrack) {
-      $scope.audioTrackDisplay = "Destory Soundtrack";
+      $scope.audioTrackDisplay = "Remove Soundtrack";
     } else {
       $scope.audioTrackDisplay = "Add Soundtrack";
     }


### PR DESCRIPTION
It would say add soundtrack when one was already present.  Changed the
'waspassed' conditional to display destroy soundtrack when one is
present and a story was passed in.