### PR TITLE
Background audio player for acts

### DIFF
--- a/client/services/storyStateMachine.js
+++ b/client/services/storyStateMachine.js
@@ -88,7 +88,7 @@ angular.module('storyBoard.storyStateMachineService',
 
     switch(storyFrame.mediaType){
       case 0:
-        player = new VideoPlayer();
+        player = new VideoPlayer(storyFrame.audioId);
         break;
       case 1:
         player = new ImagePlayer(storyFrame.narrationText);

--- a/client/services/videoPlayer.js
+++ b/client/services/videoPlayer.js
@@ -8,7 +8,6 @@ angular.module('storyBoard.videoPlayer', ['storyBoard.player'])
     this.volume = null;
     this.alreadyStopped = false;
     this.audioPlayer = null;
-    this.audioDelay = null;
 
     this.audioId = audioId || '';
     var hasAlternateAudio = this.audioId !== '';
@@ -69,7 +68,6 @@ angular.module('storyBoard.videoPlayer', ['storyBoard.player'])
     this.endPlaybackCallback = endPlaybackCallback;
     this.playingCallback = playingCallback;
     this.volume = storyFrame.volume;
-    this.audioDelay = storyFrame.audioDelay || 0;
   };
 
   VideoPlayer.prototype.destroy = function(){
@@ -80,15 +78,12 @@ angular.module('storyBoard.videoPlayer', ['storyBoard.player'])
   };
 
   VideoPlayer.prototype.play = function () {
-    var videoPlayer = this;
-    setTimeout(function(){
-      videoPlayer.alreadyStopped = false;
-      if (videoPlayer.audioPlayer) {
-        videoPlayer.audioPlayer.play();
-      }
-      videoPlayer.storyFrame.player.setVolume(parseInt(videoPlayer.volume));
-      videoPlayer.storyFrame.player.playVideo();
-    }, videoPlayer.audioDelay * 1000);
+    this.alreadyStopped = false;
+    if (this.audioPlayer) {
+      this.audioPlayer.play();
+    }
+    this.storyFrame.player.setVolume(parseInt(this.volume));
+    this.storyFrame.player.playVideo();
   };
 
   VideoPlayer.prototype.pause = function(){

--- a/client/services/videoPlayer.js
+++ b/client/services/videoPlayer.js
@@ -24,7 +24,7 @@ angular.module('storyBoard.videoPlayer', ['storyBoard.player'])
     while( ! window.youtubeApiLoadedAndReady){}
 
     if (this.audioId) {
-      this.createAudioPlayer(
+      this._createAudioPlayer(
         storyFrame, readyCallback, endPlaybackCallback, playingCallback
       );
     }

--- a/client/services/videoPlayer.js
+++ b/client/services/videoPlayer.js
@@ -54,7 +54,7 @@ angular.module('storyBoard.videoPlayer', ['storyBoard.player'])
     this.volume = storyFrame.volume;
   };
 
-  VideoPlayer.prototype.createAudioPlayer = function(storyFrame, readyCallback, endPlaybackCallback, playingCallback){
+  VideoPlayer.prototype._createAudioPlayer = function(storyFrame, readyCallback, endPlaybackCallback, playingCallback){
     var frameLength = storyFrame.start + storyFrame.end;
     var audioLength = storyFrame.audioStart + storyFrame.audioEnd;
     if (audioLength > frameLength) {

--- a/client/services/videoPlayer.js
+++ b/client/services/videoPlayer.js
@@ -23,25 +23,9 @@ angular.module('storyBoard.videoPlayer', ['storyBoard.player'])
     var VIDEO_WIDTH = 356;
     while( ! window.youtubeApiLoadedAndReady){}
 
-    if (storyFrame.audioId) {
-      var frameLength = storyFrame.start + storyFrame.end;
-      var audioLength = storyFrame.audioStart + storyFrame.audioEnd;
-      if (audioLength > frameLength) {
-        storyFrame.audioEnd = storyFrame.audioStart + (storyFrame.end - storyFrame.start)
-      }
-      var audioStoryFrame = {
-        mediaType: 0,
-        videoId: storyFrame.audioId,
-        volume: storyFrame.audioVolume,
-        start: storyFrame.audioStart,
-        end: storyFrame.audioEnd,
-        playerDiv: storyFrame.playerDiv + 'Audio',
-        player: {}
-      };
-
-      this.audioPlayer.create(
-        audioStoryFrame, readyCallback,
-        endPlaybackCallback, playingCallback
+    if (this.audioId) {
+      this.createAudioPlayer(
+        storyFrame, readyCallback, endPlaybackCallback, playingCallback
       );
     }
 
@@ -68,6 +52,28 @@ angular.module('storyBoard.videoPlayer', ['storyBoard.player'])
     this.endPlaybackCallback = endPlaybackCallback;
     this.playingCallback = playingCallback;
     this.volume = storyFrame.volume;
+  };
+
+  VideoPlayer.prototype.createAudioPlayer = function(storyFrame, readyCallback, endPlaybackCallback, playingCallback){
+    var frameLength = storyFrame.start + storyFrame.end;
+    var audioLength = storyFrame.audioStart + storyFrame.audioEnd;
+    if (audioLength > frameLength) {
+      storyFrame.audioEnd = storyFrame.audioStart + (storyFrame.end - storyFrame.start)
+    }
+    var audioStoryFrame = {
+      mediaType: 0,
+      videoId: storyFrame.audioId,
+      volume: storyFrame.audioVolume,
+      start: storyFrame.audioStart,
+      end: storyFrame.audioEnd,
+      playerDiv: storyFrame.playerDiv + 'Audio',
+      player: {}
+    };
+
+    this.audioPlayer.create(
+      audioStoryFrame, readyCallback,
+      endPlaybackCallback, playingCallback
+    );
   };
 
   VideoPlayer.prototype.destroy = function(){

--- a/client/singleStory/singleStory.html
+++ b/client/singleStory/singleStory.html
@@ -6,14 +6,17 @@
         <div class="row">
             <div class="act1 col-md-4 player-video" ng-class="act1divclass">
                 <div id="player1" class="center-it"></div>
+                <div id="player1Audio" style="display: none"></div>
             </div>
 
             <div class="act2 col-md-4 player-video" ng-class="act2divclass">
                 <div id="player2" class="center-it"></div>
+                <div id="player2Audio" style="display: none"></div>
             </div>
 
             <div class="act3 col-md-4 player-video" ng-class="act3divclass">
                 <div id="player3" class="center-it"></div>
+                <div id="player3Audio" style="display: none"></div>
             </div>
         </div>
         <div id="player0" style="visibility:hidden;"></div>

--- a/server/src/schema.go
+++ b/server/src/schema.go
@@ -52,6 +52,10 @@ type Frame struct {
 	ImageDuration  int      `json:"imageDuration"`
 	NarrationText  string   `json:"narrationText"`
 	NarrationDelay float32  `json:"narrationDelay"`
+	AudioId        string   `json:"audioId"`
+	AudioStart     float32  `json:"audioStart"`
+	AudioEnd       float32  `json:"audioEnd"`
+	AudioVolume    float32  `json:"audioVolume"`
 }
 
 // Vote Model - separate collection


### PR DESCRIPTION
VideoPlayer class can take an audioId parameter.
If it receives one, it creates a nested audioPlayer property inside iteself.
This audioPlayer property is also a VideoPlayer class.
When VideoPlayer.create() is called, it also calls audioPlayer.create().
The length of the audioPlayer is cut down to match that of the parent VideoPlayer.

The server schema was added to support an audioId, audioStart, audioEnd, and audioVolume properties.

In the html, the audioPlayer is assigned to an element with a display of none, so that it doesn't show on the page.