### PR TITLE
Removed a now unused dependency.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,6 @@
     "paper-card": "PolymerElements/paper-card#~1.0.9",
     "paper-spinner": "PolymerElements/paper-spinner#~1.1.0",
     "iron-icons": "PolymerElements/iron-icons#~1.1.1",
-    "ng-polymer-elements": "~0.3.0",
     "angular-animate": "~1.4.9"
   }
 }


### PR DESCRIPTION
We moved away from mixing Polymer with Angular so we don't use the ng-polymer-elements library anymore.